### PR TITLE
FACES-3173 - Exclude **/internal/** packages from javadoc generation

### DIFF
--- a/bridge-api/pom.xml
+++ b/bridge-api/pom.xml
@@ -121,8 +121,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<!-- MJAVADOC-275: Need version 2.8 or higher for release:prepare to generate JavaDoc -->
-					<version>2.10.3</version>
+					<version>2.10.4</version>
 					<configuration>
 						<additionalparam>-Xdoclint:all -Xdoclint:-missing</additionalparam>
 					</configuration>


### PR DESCRIPTION
This should be forward ported unless it breaks the build because of FACES-3192